### PR TITLE
feat(stretchtext): Use common ancestor for key and handle multi-eleme…

### DIFF
--- a/packages/stretchtext/src/content.ts
+++ b/packages/stretchtext/src/content.ts
@@ -1,34 +1,123 @@
 let selectedText = '';
+let originalText = '';
+let zoomLevel = 0;
+let textFragment = '';
+
+window.addEventListener('load', () => {
+  const url = window.location.href;
+  chrome.storage.local.get(url, (data) => {
+    const pageData = data[url];
+    if (pageData) {
+      for (const fragment in pageData) {
+        const zoomLevels = pageData[fragment];
+        const lastZoom = Object.keys(zoomLevels).sort().pop();
+        if (lastZoom !== '0') {
+          const textToReplace = decodeURIComponent(fragment.split('=')[1]);
+          const replacementText = zoomLevels[lastZoom];
+          replaceTextOnPage(textToReplace, replacementText);
+        }
+      }
+    }
+  });
+});
 
 document.addEventListener('selectionchange', () => {
   const selection = window.getSelection();
-  if (selection) {
+  if (selection && selection.rangeCount > 0) {
     selectedText = selection.toString();
+    const range = selection.getRangeAt(0);
+    const commonAncestor = range.commonAncestorContainer;
+    const element =
+      commonAncestor.nodeType === 1
+        ? commonAncestor
+        : commonAncestor.parentElement;
+
+    if (element) {
+      const newTextFragment = `#:~:text=${encodeURIComponent(
+        element.textContent || '',
+      )}`;
+      if (newTextFragment !== textFragment) {
+        originalText = element.textContent || '';
+        zoomLevel = 0;
+        textFragment = newTextFragment;
+      }
+    }
   }
 });
 
 document.addEventListener('wheel', (event) => {
   if (event.ctrlKey && selectedText) {
     event.preventDefault();
-    const action = event.deltaY < 0 ? 'expand' : 'summarize';
-    chrome.runtime.sendMessage({
-      action,
-      text: selectedText,
+    const direction = event.deltaY < 0 ? 1 : -1;
+    const newZoomLevel = zoomLevel + direction;
+    const url = window.location.href;
+
+    chrome.storage.local.get(url, (data) => {
+      const pageData = data[url] || {};
+      const textData = pageData[textFragment] || {};
+
+      if (textData[newZoomLevel]) {
+        replaceText(textData[newZoomLevel]);
+        zoomLevel = newZoomLevel;
+      } else {
+        const action = direction > 0 ? 'expand' : 'summarize';
+        chrome.runtime.sendMessage({
+          action,
+          text: selectedText,
+          url,
+          textFragment,
+          zoomLevel: newZoomLevel,
+        });
+      }
     });
   }
 });
 
 chrome.runtime.onMessage.addListener((request) => {
   if (request.action === 'replace') {
-    const selection = window.getSelection();
-    if (selection) {
-      const range = selection.getRangeAt(0);
-      range.deleteContents();
-      const textNode = document.createTextNode(request.text);
-      range.insertNode(textNode);
-      range.selectNode(textNode);
-      selection.removeAllRanges();
-      selection.addRange(range);
-    }
+    const url = request.url;
+    chrome.storage.local.get(url, (data) => {
+      const pageData = data[url] || {};
+      const textData = pageData[request.textFragment] || { '0': originalText };
+      textData[request.zoomLevel] = request.text;
+      pageData[request.textFragment] = textData;
+      chrome.storage.local.set({ [url]: pageData });
+      replaceText(request.text);
+      zoomLevel = request.zoomLevel;
+    });
   }
 });
+
+function replaceText(text) {
+  const selection = window.getSelection();
+  if (selection && selection.rangeCount > 0) {
+    const range = selection.getRangeAt(0);
+    const commonAncestor = range.commonAncestorContainer;
+
+    const element =
+      commonAncestor.nodeType === 1
+        ? commonAncestor
+        : commonAncestor.parentElement;
+    if (element) {
+      element.innerHTML = text;
+      selectedText = text;
+    }
+  }
+}
+
+function replaceTextOnPage(find, replace) {
+  const elements = document.getElementsByTagName('*');
+  for (let i = 0; i < elements.length; i++) {
+    const element = elements[i];
+    for (let j = 0; j < element.childNodes.length; j++) {
+      const node = element.childNodes[j];
+      if (node.nodeType === 3) {
+        const text = node.nodeValue;
+        const replacedText = text.replace(find, replace);
+        if (replacedText !== text) {
+          element.replaceChild(document.createTextNode(replacedText), node);
+        }
+      }
+    }
+  }
+}

--- a/packages/stretchtext/src/index.ts
+++ b/packages/stretchtext/src/index.ts
@@ -31,18 +31,27 @@ chrome.runtime.onMessage.addListener(async (request, sender) => {
           chrome.tabs.sendMessage(sender.tab.id, {
             action: 'replace',
             text,
+            url: request.url,
+            textFragment: request.textFragment,
+            zoomLevel: request.zoomLevel,
           });
         } catch (error) {
           console.error(`Error with Gemini API: ${error}`);
           chrome.tabs.sendMessage(sender.tab.id, {
             action: 'replace',
             text: `Error: ${error.message}`,
+            url: request.url,
+            textFragment: request.textFragment,
+            zoomLevel: request.zoomLevel,
           });
         }
       } else {
         chrome.tabs.sendMessage(sender.tab.id, {
           action: 'replace',
           text: 'API key not set. Please set it in the options page.',
+          url: request.url,
+          textFragment: request.textFragment,
+          zoomLevel: request.zoomLevel,
         });
       }
     });


### PR DESCRIPTION
…nt selections

This commit further enhances the stretchtext extension by using the text content of the common ancestor element as the key for the text fragment. This makes the key more stable and less prone to issues with selections.

This commit also includes the previous enhancements:
- The `replaceText` function now finds the common ancestor of the selected nodes and replaces its content, preventing issues with multi-element selections.
- The local storage key is now the page URL, with a new data structure to store text variations and reapply them on page load.
- `index.ts` has been updated to be compatible with these changes.